### PR TITLE
add post_type query arg for redirect to support custom post types on bulk edit

### DIFF
--- a/term-management-tools.php
+++ b/term-management-tools.php
@@ -89,6 +89,10 @@ class Term_Management_Tools {
 			$location = add_query_arg( 'taxonomy', $taxonomy, 'edit-tags.php' );
 		}
 
+		if ( isset( $_REQUEST['post_type'] ) && 'post' != $_REQUEST['post_type'] ) {
+			$location = add_query_arg( 'post_type', $_REQUEST['post_type'], $location );
+		}
+
 		wp_redirect( add_query_arg( 'message', $r ? 'tmt-updated' : 'tmt-error', $location ) );
 		die;
 	}


### PR DESCRIPTION
Bulk editing terms on custom post types redirects back to the default `post` page rather than retaining the `&post_type=custom` query arg. This should fix the issue.

P.S. Are you still seeking an adopter for this plugin? (http://scribu.net/wordpress/plugin-help-wanted.html)